### PR TITLE
Improve log message for endpoint to rule out potential Fastly issues

### DIFF
--- a/application/institutions.mjs
+++ b/application/institutions.mjs
@@ -29,7 +29,12 @@ export async function readInstitutionsFromEndpoint(
    *  Changes to the reference data are expected to propagate in ~2hrs
    */
 
-  console.log(endpoint);
+  if(!URL.canParse(endpoint)) {
+    console.log("⚠️ Invalid endpoint provided for reading institutions: " + endpoint);
+  }
+
+  console.log("🔗Institutions endpoint: " + endpoint + " ...");
+
   const url = new URL(endpoint);
 
   url.search = new URLSearchParams({
@@ -37,9 +42,25 @@ export async function readInstitutionsFromEndpoint(
     ...(count ? { offset: count * limit } : {}),
   });
 
+
+  console.log("🔗Fetching institutions from: " + url);
+
   const response = await fetch(url);
 
-  const { rowCount, rows } = await response.json();
+  const jsonResponse = await response.json();
+
+  const neededKeys = ["rowCount", "rows"];
+
+  if(!(neededKeys.every((key) => Object.keys(jsonResponse).includes(key)))) {
+    console.error("⚠️ Invalid response from endpoint " + endpoint + ", as it does not contain required keys: "+JSON.stringify(neededKeys));
+    console.error("⚠️ Server responded instead with: " + await response.text());
+    return {
+      rowCount: getRowCount(accumulator),
+      rows: getRows(accumulator)
+    };
+  }
+
+  const {rowCount, rows} = jsonResponse;
 
   const institutions = {
     rowCount: getRowCount(accumulator) + rowCount,

--- a/application/institutions.mjs
+++ b/application/institutions.mjs
@@ -29,11 +29,11 @@ export async function readInstitutionsFromEndpoint(
    *  Changes to the reference data are expected to propagate in ~2hrs
    */
 
-  if(!URL.canParse(endpoint)) {
-    console.log("⚠️ Invalid endpoint provided for reading institutions: " + endpoint);
+  if (!URL.canParse(endpoint)) {
+    console.log('⚠️ Invalid endpoint provided for reading institutions: ' + endpoint);
   }
 
-  console.log("🔗Institutions endpoint: " + endpoint + " ...");
+  console.log('🔗Institutions endpoint: ' + endpoint + ' ...');
 
   const url = new URL(endpoint);
 
@@ -43,30 +43,30 @@ export async function readInstitutionsFromEndpoint(
   });
 
 
-  console.log("🔗Fetching institutions from: " + url);
+  console.log('🔗Fetching institutions from: ' + url);
 
   const response = await fetch(url);
 
   const jsonResponse = await response.json();
 
-  const neededKeys = ["rowCount", "rows"];
+  const neededKeys = ['rowCount', 'rows'];
 
-  if(!(neededKeys.every((key) => Object.keys(jsonResponse).includes(key)))) {
-    console.error("⚠️ Invalid response from endpoint " + endpoint + ", as it does not contain required keys: "+JSON.stringify(neededKeys));
-    console.error("⚠️ Server responded instead with: " + await response.text());
-    return {
-      rowCount: getRowCount(accumulator),
-      rows: getRows(accumulator)
-    };
+  if (!(neededKeys.every((key) => Object.keys(jsonResponse).includes(key)))) {
+    console.error('⚠️ Invalid response from endpoint ' + endpoint + ', as it does not contain required keys: ' + JSON.stringify(neededKeys));
+    console.error('⚠️ Server responded instead with: ' + await response.text());
+    throw new Error('Unable to fetch institutions from refdata-api at endpoint ' + endpoint);
   }
 
-  const {rowCount, rows} = jsonResponse;
+  const { rowCount, rows } = jsonResponse;
+
+  console.log('ℹ️ Fetched ' + rows.length + ' rows from ' + url + '. API returned rowCount = ' + rowCount);
 
   const institutions = {
     rowCount: getRowCount(accumulator) + rowCount,
     rows: getRows(accumulator).concat(rows),
   };
 
+  // if we get a full page of results, there may be some more to fetch
   if (rowCount === limit) {
     return readInstitutionsFromEndpoint(endpoint, limit, count + 1, institutions);
   }

--- a/scripts/sync.mjs
+++ b/scripts/sync.mjs
@@ -25,7 +25,13 @@ async function app() {
   console.log('🚀');
 
   const was = await readInstitutionsFromFilePath(FILE_PATH);
-  const now = await readInstitutionsFromEndpoint(ENDPOINT, LIMIT, COUNT);
+  let now = undefined;
+
+  try {
+    now = await readInstitutionsFromEndpoint(ENDPOINT, LIMIT, COUNT);
+  } catch(error) {
+    console.error('Something went wrong reading the institutions from the refdata-api. Institution reconciliation will not work with a partial list of institutions, so I am bailing out!')
+  }
 
   if (!isDeepStrictEqual(was, now)) {
     await change(getChangedInstitutions(was, now));


### PR DESCRIPTION
We are seeing sporadic crashes in production with a long HTML being printed by the pod just before it dies.

I suspect that the refdata-api sometimes returns HTML instead of JSON, which crashes the sync process. 

This PR tries to handle those cases better, and improve the logging to confirm my suspicions.


Here are the New Relic dashboards showing the restarts that happen once in a while:

https://one.eu.newrelic.com/nr1-core/container/metrics/MjM3ODI3MnxJTkZSQXxOQXwxMzU3MzUwNTcwMzE0Mzk4NDUw?account=2378272&duration=86400000&filters=%28name%20LIKE%20%27institutions%27%20OR%20id%20%3D%20%27institutions%27%20OR%20domainId%20%3D%20%27institutions%27%29&state=e89dfa4d-dd19-8b8a-7eab-b15765a08a78

Here is a screenshot of the logs when the pod crashed recently:

![Screenshot from 2024-06-05 15-23-37](https://github.com/THE-Engineering/sync-from-the-institutions-to-auth0-organizations/assets/2529555/ddfe9f5c-0b4e-4eba-8799-e47c0d9e54cf)


